### PR TITLE
Fixed case of first job run

### DIFF
--- a/nakivo_prometheus_exporter/prom_parser.py
+++ b/nakivo_prometheus_exporter/prom_parser.py
@@ -154,6 +154,9 @@ def get_vm_backup_result(job_result: dict, host: str, filter_active_only: bool =
         for vm in job["objects"]:
             name = vm["sourceName"]
             state = vm["lrState"]
+            # If the state is null, it means that the VM is being saved for the first time
+            if state is None:
+                state = "RUNNING"
             if state in ("SUCCEEDED"):
                 num_state = 0
             elif state in ("RUNNING", "DEMAND", "SCHEDULED", "WAITING"):

--- a/nakivo_prometheus_exporter/prom_parser.py
+++ b/nakivo_prometheus_exporter/prom_parser.py
@@ -156,8 +156,8 @@ def get_vm_backup_result(job_result: dict, host: str, filter_active_only: bool =
             state = vm["lrState"]
             # If the state is null, it means that the VM is being saved for the first time
             if state is None:
-                state = "RUNNING"
-            if state in ("SUCCEEDED"):
+                num_state = 1
+            elif state in ("SUCCEEDED"):
                 num_state = 0
             elif state in ("RUNNING", "DEMAND", "SCHEDULED", "WAITING"):
                 num_state = 1


### PR DESCRIPTION
In case a VM backup is ran for the first time in a job the lrState of it will be None, which would break the parsing and exclude the whole host from showing in the metrics.
I added a check so if the lrState is None, it will be considered as ~~"RUNNING"~~ num_state=1